### PR TITLE
CS bonus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akatsuki-pp"
-version = "0.4.2"
+version = "0.4.5"
 authors = ["MaxOhn <ohn.m@hotmail.de>", "tsunyoku <tsunyoku@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akatsuki-pp"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["MaxOhn <ohn.m@hotmail.de>", "tsunyoku <tsunyoku@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/osu/gradual_difficulty.rs
+++ b/src/osu/gradual_difficulty.rs
@@ -78,6 +78,7 @@ impl OsuGradualDifficultyAttributes {
         let mut attributes = OsuDifficultyAttributes {
             ar: map_attributes.ar,
             hp: map_attributes.hp,
+            cs: map_attributes.cs,
             od,
             ..Default::default()
         };

--- a/src/osu/mod.rs
+++ b/src/osu/mod.rs
@@ -455,6 +455,8 @@ pub struct OsuDifficultyAttributes {
     pub od: f64,
     /// The health drain rate.
     pub hp: f64,
+    // The circle size.
+    pub cs: f64,
     /// The amount of circles.
     pub n_circles: usize,
     /// The amount of sliders.

--- a/src/osu/mod.rs
+++ b/src/osu/mod.rs
@@ -191,6 +191,7 @@ fn calculate_skills(
     let mut attributes = OsuDifficultyAttributes {
         ar: map_attributes.ar,
         hp: map_attributes.hp,
+        cs: map_attributes.cs,
         od,
         ..Default::default()
     };

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -411,7 +411,7 @@ impl OsuPPInner {
         // CS bonus
         if attributes.cs > 6.0 {            
             let diff = attributes.cs - 6.0;
-            aim_value *= 1.0 + (diff / 50.0);  
+            aim_value *= 1.0 + (diff / 20.0);  
         };
         
         // HD bonus (this would include the Blinds mod but it's currently not representable)

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -409,14 +409,14 @@ impl OsuPPInner {
         aim_value *= 1.0 + ar_factor * len_bonus; // * Buff for longer maps with high AR.
         
         // CS bonus
-        if attributes.cs > 5.7 {            
-            diff = attributes.cs - 5.7;
+        if attributes.cs > 6 {            
+            diff = attributes.cs - 6;
             aim_value *= 1.0 + (diff / 50.0);  
         };
         
         // HD bonus (this would include the Blinds mod but it's currently not representable)
         if self.mods.hd() {
-            aim_value *= 1.0 + 0.04 * (12.0 - attributes.ar);
+            aim_value *= 1.04 * (12.0 - attributes.ar);
         }
 
         if attributes.n_sliders > 0 {

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -350,21 +350,10 @@ impl OsuPPInner {
             multiplier *= 1.0 - (n_spinners as f64 / self.total_hits).powf(0.85);
         }
 
-        let mut aim_value = self.compute_aim_value();
-        let mut speed_value = self.compute_speed_value();
+        let aim_value = self.compute_aim_value();
+        let speed_value = self.compute_speed_value();
         let acc_value = self.compute_accuracy_value();
         let flashlight_value = self.compute_flashlight_value();
-
-        if self.mods.rx() {
-            let speed_crosscheck: f64 = aim_value / speed_value;
-
-            if speed_crosscheck < 1.0 {
-                let crosscheck_multiplier: f64 = f64::min(1.0, 0.735 * speed_crosscheck);
-
-                aim_value *= f64::max(0.1, crosscheck_multiplier);
-                speed_value *= f64::max(0.1, crosscheck_multiplier);
-            }
-        }
 
         let pp = (aim_value.powf(1.1)
             + speed_value.powf(1.1)
@@ -420,9 +409,9 @@ impl OsuPPInner {
         aim_value *= 1.0 + ar_factor * len_bonus; // * Buff for longer maps with high AR.
         
         // CS bonus
-        if attributes.cs > 6.0 {            
+        if attributes.cs > 6.0 && if self.mods.rx() {            
             let diff = attributes.cs - 6.0;
-            aim_value *= 1.03 + (diff / 20.0);  
+            aim_value *= 1.0 + (diff / 50.0);  
         };
         
         // HD bonus (this would include the Blinds mod but it's currently not representable)

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -411,7 +411,7 @@ impl OsuPPInner {
         // CS bonus
         if attributes.cs > 6.0 {            
             let diff = attributes.cs - 6.0;
-            aim_value *= 1.0 + (diff / 20.0);  
+            aim_value *= 1.03 + (diff / 20.0);  
         };
         
         // HD bonus (this would include the Blinds mod but it's currently not representable)

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -350,11 +350,22 @@ impl OsuPPInner {
             multiplier *= 1.0 - (n_spinners as f64 / self.total_hits).powf(0.85);
         }
 
-        let aim_value = self.compute_aim_value();
-        let speed_value = self.compute_speed_value();
+        let mut aim_value = self.compute_aim_value();
+        let mut speed_value = self.compute_speed_value();
         let acc_value = self.compute_accuracy_value();
         let flashlight_value = self.compute_flashlight_value();
 
+        if self.mods.rx() {
+            let speed_crosscheck: f64 = aim_value / speed_value;
+
+            if speed_crosscheck < 1.0 {
+                let crosscheck_multiplier: f64 = f64::min(1.0, 0.735 * speed_crosscheck);
+
+                aim_value *= f64::max(0.1, crosscheck_multiplier);
+                speed_value *= f64::max(0.1, crosscheck_multiplier);
+            }
+        }
+        
         let pp = (aim_value.powf(1.1)
             + speed_value.powf(1.1)
             + acc_value.powf(1.1)
@@ -411,7 +422,7 @@ impl OsuPPInner {
         // CS bonus
         if attributes.cs > 6.0 && if self.mods.rx() {            
             let diff = attributes.cs - 6.0;
-            aim_value *= 1.0 + (diff / 50.0);  
+            aim_value *= 1.03 + (diff / 20.0);  
         };
         
         // HD bonus (this would include the Blinds mod but it's currently not representable)

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -409,11 +409,9 @@ impl OsuPPInner {
         aim_value *= 1.0 + ar_factor * len_bonus; // * Buff for longer maps with high AR.
         
         // CS bonus
-        let cs_factor = if attributes.cs > 5.7 {            
-            diff = attributes.cs - 5.7
-            aim_value *= 1.0 + (diff / 50.0)
-        } else {
-            aim_value = 1.0     
+        if attributes.cs > 5.7 {            
+            diff = attributes.cs - 5.7;
+            aim_value *= 1.0 + (diff / 50.0);  
         };
         
         // HD bonus (this would include the Blinds mod but it's currently not representable)

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -409,8 +409,8 @@ impl OsuPPInner {
         aim_value *= 1.0 + ar_factor * len_bonus; // * Buff for longer maps with high AR.
         
         // CS bonus
-        if attributes.cs > 6 {            
-            diff = attributes.cs - 6;
+        if attributes.cs > 6.0 {            
+            let diff = attributes.cs - 6.0;
             aim_value *= 1.0 + (diff / 50.0);  
         };
         

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -405,9 +405,17 @@ impl OsuPPInner {
         } else {
             0.0
         };
-
+        
         aim_value *= 1.0 + ar_factor * len_bonus; // * Buff for longer maps with high AR.
-
+        
+        // CS bonus
+        let cs_factor = if attributes.cs > 5.7 {            
+            diff = attributes.cs - 5.7
+            aim_value *= 1.0 + (diff / 50.0)
+        } else {
+            aim_value = 1.0     
+        };
+        
         // HD bonus (this would include the Blinds mod but it's currently not representable)
         if self.mods.hd() {
             aim_value *= 1.0 + 0.04 * (12.0 - attributes.ar);


### PR DESCRIPTION
Closes #16 
This addition gives maps that are precise and tricky to aim more performance points. The base CS is 6, and the bonus pp scales up as the CS scales up.